### PR TITLE
Implemented JGraphT library and serialization test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    implementation 'org.jeasy:easy-states:2.0.0'
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'org.jgrapht:jgrapht-core:1.5.2'
+    implementation 'org.jgrapht:jgrapht-io:1.5.1'
 }
 
 test {

--- a/src/main/java/test.java
+++ b/src/main/java/test.java
@@ -1,5 +1,0 @@
-public class test {
-    public static void main(String[] args){
-        System.out.println("Hello");
-    }
-}

--- a/src/test/java/test.java
+++ b/src/test/java/test.java
@@ -1,0 +1,42 @@
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.nio.dot.DOTExporter;
+import org.jgrapht.nio.dot.DOTImporter;
+import java.io.*;
+
+public class test {
+    public static void main(String[] args) throws IOException {
+        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
+
+        // Sample graph based on the simple open, close, error FSM for files
+        String open = "Open";
+        String close = "Close";
+        String error = "Error";
+        g.addVertex(open);
+        g.addVertex(close);
+        g.addVertex(error);
+
+        g.addEdge(open,close);
+        g.addEdge(close,close);
+        g.addEdge(open,error);
+
+        System.out.println(g);
+
+        // Exports the graph into DOT format
+        DOTExporter<String, DefaultEdge> de = new DOTExporter<>(Vertex -> Vertex);
+        de.exportGraph(g, new File("test2"));
+
+
+        //Imports graph object from DOT format
+        DefaultDirectedGraph<String, DefaultEdge> g2 = new DefaultDirectedGraph<>(DefaultEdge.class);
+        DOTImporter<String,DefaultEdge> di = new DOTImporter<>();
+        di.setVertexFactory(v -> v);
+        di.importGraph(g2, new FileReader("test2"));
+
+
+
+        System.out.println(g2);
+
+    }
+}


### PR DESCRIPTION
## Description

Implemented serialization test via built-in methods representing simple file open, close FSM

## Notes

- JGraphT supports DOT format serialization, which seems easier to read and create from text
- JGraphT also supports JSON serialization, although I haven't tested it yet
- Extra work is required to get serialization/deserialization working with custom namable edge class
- This library supports a multitude of classic graph algorithms, which will aid in my algorithm creation

## Future work

- Look for ways to implement custom edge class to support naming edges in serialization and deserialization If needed
