### PR TITLE
Implemented test dealing with identifying error-inducing subsequences

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,4 @@
 rootProject.name = 'research'
+include 'src:main:java'
+findProject(':src:main:java')?.name = 'java'
 

--- a/src/main/java/MyUtils.java
+++ b/src/main/java/MyUtils.java
@@ -1,0 +1,28 @@
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.AllDirectedPaths;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class MyUtils {
+    /**
+     * Method to print out all paths in a FSM/graph that start in any state (except err) and end in the err state.
+     *
+     * @param inputG the directed graph from which to obtain all error sequences and subsequences.
+     * @return a set of all error-inducing subsequences (paths) in the FSM.
+     */
+    public Set<GraphPath<String, DefaultEdge>> allErrPaths(DefaultDirectedGraph<String, DefaultEdge> inputG) {
+        AllDirectedPaths<String, DefaultEdge> allPathSupplier = new AllDirectedPaths<>(inputG);
+        HashSet<GraphPath<String, DefaultEdge>> setPaths = new HashSet<>();
+        for (String vertex : inputG.vertexSet()) {
+            if (!vertex.equals("err")) {
+                List<GraphPath<String, DefaultEdge>> allPaths = allPathSupplier.getAllPaths(vertex, "err", true, null);
+                setPaths.addAll(allPaths);
+            }
+        }
+        return setPaths;
+    }
+}

--- a/src/test/java/AlgoTest.java
+++ b/src/test/java/AlgoTest.java
@@ -1,0 +1,74 @@
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.AllDirectedPaths;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.nio.dot.DOTImporter;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test Class specializing in Algorithm testing.
+ */
+public class AlgoTest {
+
+    /**
+     * Method to print out all paths in a FSM/graph that start in any state (except err) and end in the err state.
+     *
+     * @param inputG the directed graph to obtain all error sequences and subsequences from.
+     * @return a set of all error-inducing subsequences (paths) in the FSM.
+     */
+    private Set<GraphPath<String, DefaultEdge>> allErrPaths(DefaultDirectedGraph<String, DefaultEdge> inputG) {
+        AllDirectedPaths<String, DefaultEdge> allPathSupplier = new AllDirectedPaths<>(inputG);
+        HashSet<GraphPath<String, DefaultEdge>> setPaths = new HashSet<>();
+        for (String vertex : inputG.vertexSet()) {
+            if (!vertex.equals("err")) {
+                List<GraphPath<String, DefaultEdge>> allPaths = allPathSupplier.getAllPaths(vertex, "err", true, null);
+                setPaths.addAll(allPaths);
+            }
+        }
+        return setPaths;
+    }
+
+    /**
+     * Tests input of supplied FSM and output of all error-inducing subsequences for non-accumulation typestate FSM 3.3: C-style pointers.
+     *
+     * @throws IOException when provided 'algo-test1' file is not found or error in reading file.
+     */
+    @Test
+    public void algoTest1() throws IOException {
+        DefaultDirectedGraph<String, DefaultEdge> algoGraph1 = new DefaultDirectedGraph<>(DefaultEdge.class);
+        DOTImporter<String, DefaultEdge> importer = new DOTImporter<>();
+        importer.setVertexFactory(Function.identity());
+        try (FileReader reader = new FileReader("src/test/resources/algo-test1")) {
+            importer.importGraph(algoGraph1, reader);
+        }
+        Set<GraphPath<String, DefaultEdge>> errSubseqs = allErrPaths(algoGraph1);
+        //If the found number of error-inducing subsequences is not equal, immediately fail testcase
+        assertEquals(errSubseqs.size(), 8, "# of error-inducing subsequences does not match");
+
+        // Set of predetermined (manually found) expected results
+        // String representation of all subsequences/paths
+        HashSet<String> expectedSet = new HashSet<>();
+        expectedSet.add("[(valid:dangle),(dangle:null),(null:err)]");
+        expectedSet.add("[(valid:dangle),(dangle:err)]");
+        expectedSet.add("[(valid:null),(null:err)]");
+        expectedSet.add("[(dangle:valid),(valid:null),(null:err)]");
+        expectedSet.add("[(dangle:null),(null:err)]");
+        expectedSet.add("[(dangle:err)]");
+        expectedSet.add("[(null:valid),(valid:dangle),(dangle:err)]");
+        expectedSet.add("[(null:err)]");
+
+        for (GraphPath<String, DefaultEdge> x : errSubseqs) {
+            assertTrue(expectedSet.contains(x.toString().replaceAll("\\s", "")), "error-inducing subsequence mismatch");
+        }
+    }
+}

--- a/src/test/java/AlgoTest.java
+++ b/src/test/java/AlgoTest.java
@@ -1,5 +1,4 @@
 import org.jgrapht.GraphPath;
-import org.jgrapht.alg.shortestpath.AllDirectedPaths;
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.nio.dot.DOTImporter;
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -19,24 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Test Class specializing in Algorithm testing.
  */
 public class AlgoTest {
-
-    /**
-     * Method to print out all paths in a FSM/graph that start in any state (except err) and end in the err state.
-     *
-     * @param inputG the directed graph to obtain all error sequences and subsequences from.
-     * @return a set of all error-inducing subsequences (paths) in the FSM.
-     */
-    private Set<GraphPath<String, DefaultEdge>> allErrPaths(DefaultDirectedGraph<String, DefaultEdge> inputG) {
-        AllDirectedPaths<String, DefaultEdge> allPathSupplier = new AllDirectedPaths<>(inputG);
-        HashSet<GraphPath<String, DefaultEdge>> setPaths = new HashSet<>();
-        for (String vertex : inputG.vertexSet()) {
-            if (!vertex.equals("err")) {
-                List<GraphPath<String, DefaultEdge>> allPaths = allPathSupplier.getAllPaths(vertex, "err", true, null);
-                setPaths.addAll(allPaths);
-            }
-        }
-        return setPaths;
-    }
 
     /**
      * Tests input of supplied FSM and output of all error-inducing subsequences for non-accumulation typestate FSM 3.3: C-style pointers.
@@ -51,7 +31,8 @@ public class AlgoTest {
         try (FileReader reader = new FileReader("src/test/resources/algo-test1")) {
             importer.importGraph(algoGraph1, reader);
         }
-        Set<GraphPath<String, DefaultEdge>> errSubseqs = allErrPaths(algoGraph1);
+        MyUtils utils = new MyUtils();
+        Set<GraphPath<String, DefaultEdge>> errSubseqs = utils.allErrPaths(algoGraph1);
         //If the found number of error-inducing subsequences is not equal, immediately fail testcase
         assertEquals(errSubseqs.size(), 8, "# of error-inducing subsequences does not match");
 

--- a/src/test/resources/algo-test1
+++ b/src/test/resources/algo-test1
@@ -1,0 +1,14 @@
+// C-style pointers FSM 3.3
+strict digraph G {
+  valid;
+  dangle;
+  null;
+  err;
+  valid -> dangle;
+  valid -> null;
+  dangle -> null;
+  dangle -> valid;
+  dangle -> err;
+  null -> valid;
+  null -> err;
+}


### PR DESCRIPTION
# Description

Utilized JGraphT's ```getAllPaths``` method to extract all possible subsequences that end in the error (err) state.

## Actions
- Created AlgoTest class file to house algorithm-related tests
- Created "algo-test1" DOT formatted file to import FSM below:
![TS1](https://github.com/user-attachments/assets/212739d7-1563-4e2d-87cc-c70f01bae504)


## Future Work
- Test creation/exporting of sub-FSMs that fit accumulation typestate definition from inputted FSM.
- Potentially test more non-accumulation FSMs 

## References
This FSM representation is adapted from:
Qi Gao, Wenbin Zhang, Zhezhe Chen, Mai Zheng, and Feng Qin. *2ndstrike: toward manifesting hidden concurrency typestate bugs*. ACM Sigplan Notices, 46(3):239-250, 2011.
