### PR TITLE
Lib/jgt/refactor2

### DIFF
--- a/src/main/java/MyUtils.java
+++ b/src/main/java/MyUtils.java
@@ -5,6 +5,7 @@ import org.jgrapht.graph.DefaultDirectedGraph;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -75,6 +76,40 @@ public class MyUtils {
                 }
             }
             return graph;
+        }
+    }
+    /**
+     * Generates all non-empty, ordered sub paths from a given GraphPath.
+     *
+     * @param path the GraphPath from which to generate sub paths
+     * @return a list of lists, where each inner list is a non-empty ordered sub path of edges from the path parameter
+     */
+    public List<List<LabeledEdge>> generateSubpaths(GraphPath<String, LabeledEdge> path) {
+            List<LabeledEdge> edgeList = new ArrayList<>(path.getEdgeList());
+        List<List<LabeledEdge>> subpaths = new ArrayList<>();
+        subpathHelper(edgeList, new ArrayList<>(), subpaths);
+        // Will remove all subpaths that arent valid (possible) or do not start with the original
+        // path's starting vertex
+
+        return subpaths;
+    }
+
+    /**
+     * A recursive helper method to generate all non-empty ordered subsets of edges.
+     *
+     * @param edgeList the original list of edges
+     * @param current the current subset of edges being constructed
+     * @param subpaths a list to store all non-empty subsets of edges
+     */
+    private void subpathHelper(List<LabeledEdge> edgeList, List<LabeledEdge> current, List<List<LabeledEdge>> subpaths) {
+        if (!current.isEmpty()) {
+            subpaths.add(new ArrayList<>(current));
+        }
+        for (int i = 0; i < edgeList.size(); i++) {
+            LabeledEdge edge = edgeList.get(i);
+            current.add(edge);
+            subpathHelper(edgeList.subList(i + 1, edgeList.size()), current, subpaths);
+            current.remove(current.size() - 1);
         }
     }
 }

--- a/src/main/java/MyUtils.java
+++ b/src/main/java/MyUtils.java
@@ -5,6 +5,7 @@ import org.jgrapht.graph.DefaultDirectedGraph;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -88,9 +89,6 @@ public class MyUtils {
             List<LabeledEdge> edgeList = new ArrayList<>(path.getEdgeList());
         List<List<LabeledEdge>> subpaths = new ArrayList<>();
         subpathHelper(edgeList, new ArrayList<>(), subpaths);
-        // Will remove all subpaths that arent valid (possible) or do not start with the original
-        // path's starting vertex
-
         return subpaths;
     }
 

--- a/src/test/java/AlgoTest.java
+++ b/src/test/java/AlgoTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/AlgoTest.java
+++ b/src/test/java/AlgoTest.java
@@ -5,8 +5,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
+
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,5 +66,29 @@ public class AlgoTest {
         validGraphs.add("([NotStudying,Playing,Sleeping],[Play=(NotStudying,Playing),Sleep=(Playing,Sleeping)])");
         validGraphs.add("([NotStudying,Sleeping],[Sleep=(NotStudying,Sleeping)])");
         assertTrue(pathGraphs.containsAll(validGraphs));
+    }
+    /**
+     * Tests the generateSubpaths method on the Error-inducing subsequences generated from a DOT file FSM.
+     *
+     * @throws IOException if an I/O error occurs during the reading of the DOT file.
+     */
+    @Test
+    public void subpathTest1() throws IOException {
+        MyUtils utils = new MyUtils();
+        DefaultDirectedGraph<String, LabeledEdge> origGraph = utils.dotToFSM("src/test/resources/algo-test2");
+        List<String> expectedSubpaths = new ArrayList<>();
+        expectedSubpaths.add("[next(true)]");
+        expectedSubpaths.add("[next(true), next(false)]");
+        expectedSubpaths.add("[next(true), next(true)]");
+        expectedSubpaths.add("[next(true), next(false), next(true)]");
+        expectedSubpaths.add("[next(false), next(true)]");
+        expectedSubpaths.add("[next(false)]");
+        Set<List<LabeledEdge>> generatedErrSubpaths = new TreeSet<>(Comparator.comparing(List<LabeledEdge>::toString));
+        for(GraphPath<String,LabeledEdge> errPath : utils.allErrPaths(origGraph)){
+            generatedErrSubpaths.addAll(utils.generateSubpaths(errPath));
+        }
+        for(List<LabeledEdge> subpath : generatedErrSubpaths){
+            assertTrue(expectedSubpaths.contains(subpath.toString()));
+        }
     }
 }

--- a/src/test/resources/algo-test2
+++ b/src/test/resources/algo-test2
@@ -1,0 +1,13 @@
+// Database next row FSM 3.41
+strict digraph G {
+    start;
+    row;
+    end;
+    err;
+    start -> row [ label="next(true)" ];
+    start -> end [ label="next(false)" ];
+    row -> row [ label="next(true)" ];
+    row -> end [ label="next(false)" ];
+    end -> err [ label="next(true)" ];
+    end -> err [ label="next(false)" ];
+}


### PR DESCRIPTION
## Notes
- Added generateSubpaths method with subpathHelper method to perform recursive solution
- Created subpathTest1 to test out these methods which will be useful in the main algorithm
## Future work
- Currently, the DefaultDirectedGraph doesnt support "identical" edges (edges that have the same source and target), even with different labels. 
- As a result, refactoring to the type "DirectedMultigraph" can fix this issue **HOWEVER** DirectedMultigraphs by design do not allow looping edges.