### PR TITLE
Reformatted code based on feedback

### DIFF
--- a/src/main/java/LabeledEdge.java
+++ b/src/main/java/LabeledEdge.java
@@ -1,19 +1,30 @@
 import org.jgrapht.graph.DefaultEdge;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 /**
  * LabeledEdge class extending DefaultEdge to give
  * edges/transitions in FSMs/Graphs labels.
  */
 public class LabeledEdge extends DefaultEdge {
-    private final String label;
+    private final ArrayList<String> labels;
 
     /**
      * Constructs a LabeledEdge with the specified label.
      *
-     * @param label the label associated with this edge
+     * @param labels the label(s) associated with this edge
      */
-    public LabeledEdge(String label) {
-        this.label = label;
+    public LabeledEdge(String... labels) {
+        this.labels = new ArrayList<>(Arrays.asList(labels));
+    }
+
+    /**
+     * Constructs a LabeledEdge with the specific list of labels
+     *
+     * @param labels A list containing multiple labels that represent the edge
+     */
+    public LabeledEdge(ArrayList<String> labels) {
+        this.labels = labels;
     }
 
     /**
@@ -35,21 +46,37 @@ public class LabeledEdge extends DefaultEdge {
     }
 
     /**
-     * Returns the label associated with this edge.
+     * Returns the list of labels of this edge
      *
-     * @return the label
+     * @return the ArrayList of labels
      */
-    public String getLabel() {
-        return label;
+    public ArrayList<String> getLabels(){
+        return labels;
     }
-
     /**
-     * String representation of this edge is just the label.
+     * Adds a label to the labels list
      *
-     * @return the label of this edge
+     * @param label the label which is being added
+     */
+    public void addLabel(String label){
+        labels.add(label);
+    }
+    /**
+     * String representation of this edge is just the label, or all labels is multiple are present.
+     *
+     * @return the label of this edge, or list of labels if there are multiple labels
      */
     @Override
     public String toString() {
-        return label;
+        if(labels.size()==1) return labels.get(0);
+        return labels.toString();
+    }
+    /**
+     * Checks the equality of two labeled edges based on label, source, and target
+     *
+     * @return boolean of whether two edges are equivalent
+     */
+    boolean equals(LabeledEdge edge2){
+        return labels.equals(edge2.getLabels()) && this.getSource().equals(edge2.getSource()) && this.getTarget().equals(edge2.getTarget());
     }
 }

--- a/src/test/java/AlgoTest.java
+++ b/src/test/java/AlgoTest.java
@@ -5,11 +5,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,19 +26,19 @@ public class AlgoTest {
     public void algoTest1() throws IOException {
         MyUtils utils = new MyUtils();
         DefaultDirectedGraph<String, LabeledEdge> algoGraph1 = utils.dotToFSM("src/test/resources/algo-test1");
-        Set<GraphPath<String, LabeledEdge>> errSubseqs = utils.allErrPaths(algoGraph1);
+        Set<GraphPath<String, LabeledEdge>> errSubseqs = utils.allErrPaths(algoGraph1,"valid");
         //If the found number of error-inducing subsequences is not equal, immediately fail testcase
-        assertEquals(errSubseqs.size(), 8, "# of error-inducing subsequences does not match");
+        assertEquals(errSubseqs.size(), 6, "# of error-inducing subsequences does not match");
 
         // Set of predetermined (manually found) expected results
         // String representation of all subsequences/paths
         HashSet<String> expectedSet = new HashSet<>();
-        expectedSet.add("[free, assign null, free]");
+        expectedSet.add("[assign valid, free, free]");
         expectedSet.add("[free, free]");
         expectedSet.add("[assign null, free]");
         expectedSet.add("[assign valid, assign null, free]");
-        expectedSet.add("[free]");
-        expectedSet.add("[assign valid, free, free]");
+        expectedSet.add("[free, assign null, free]");
+        expectedSet.add("[assign valid, free, assign null, free]");
         for (GraphPath<String, LabeledEdge> x : errSubseqs) {
             assertTrue(expectedSet.contains(x.toString()), "error-inducing subsequence mismatch");
         }
@@ -76,18 +74,20 @@ public class AlgoTest {
         MyUtils utils = new MyUtils();
         DefaultDirectedGraph<String, LabeledEdge> origGraph = utils.dotToFSM("src/test/resources/algo-test2");
         List<String> expectedSubpaths = new ArrayList<>();
+        Set<String> generatedErrSubpathsString = new HashSet<>();
         expectedSubpaths.add("[next(true)]");
+        expectedSubpaths.add("[next(false), [next(true), next(false)]]");
         expectedSubpaths.add("[next(true), next(false)]");
-        expectedSubpaths.add("[next(true), next(true)]");
-        expectedSubpaths.add("[next(true), next(false), next(true)]");
-        expectedSubpaths.add("[next(false), next(true)]");
+        expectedSubpaths.add("[next(true), next(false), [next(true), next(false)]]");
         expectedSubpaths.add("[next(false)]");
-        Set<List<LabeledEdge>> generatedErrSubpaths = new TreeSet<>(Comparator.comparing(List<LabeledEdge>::toString));
-        for(GraphPath<String,LabeledEdge> errPath : utils.allErrPaths(origGraph)){
-            generatedErrSubpaths.addAll(utils.generateSubpaths(errPath));
+        expectedSubpaths.add("[[next(true), next(false)]]");
+        for(GraphPath<String,LabeledEdge> errPath : utils.allErrPaths(origGraph,"start")){
+            for(GraphPath<String,LabeledEdge> subErrPath : utils.generateSubpaths(errPath)){
+                generatedErrSubpathsString.add(subErrPath.toString());
+            }
         }
-        for(List<LabeledEdge> subpath : generatedErrSubpaths){
-            assertTrue(expectedSubpaths.contains(subpath.toString()));
-        }
+        assertTrue(expectedSubpaths.containsAll(generatedErrSubpathsString));
+        assertTrue(generatedErrSubpathsString.containsAll(expectedSubpaths));
+
     }
 }

--- a/src/test/resources/algo-test1
+++ b/src/test/resources/algo-test1
@@ -4,11 +4,13 @@ strict digraph G {
   dangle;
   null;
   err;
+  valid -> valid [ label="assign valid" ];
   valid -> dangle [ label="free" ];
   valid -> null [ label="assign null" ];
   dangle -> null [ label="assign null" ];
   dangle -> valid [ label="assign valid" ];
   dangle -> err [ label="free" ];
   null -> valid [ label="assign valid" ];
+  null -> null [ label="assign null" ];
   null -> err [ label="free" ];
 }


### PR DESCRIPTION
## Changes/Additions
- Added `listToPath` method to allow conversion from a list of `LabeledEdge` to `GraphPath`.
- Changed `generateSubpaths` to return a set to prevent duplicate `GraphPath` from being returned.
- `LabeledEdge` class can now hold a list of labels instead of a single label to simulate multiple identical edges.
- Changed `allErrPaths` method to require the specification of a starting vertex to generate paths from.

## Note
The reasoning for changing `allErrPaths` to require a specified start vertex is to prevent overlap when generating every error path from any starting vertex (except the error vertex). By adding this requirement, we can easily identify the starting vertex of a set of paths and avoid this overlap/overwrite of visually identical paths.